### PR TITLE
Fixing loopholes in the firewall

### DIFF
--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -24,7 +24,7 @@
 -A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 
 # Pings
--A OUTPUT -p icmp -i vnoi-vpn -j ACCEPT
+-A OUTPUT -p icmp -o vnoi-vpn -j ACCEPT
 # SSH
 -A OUTPUT -p tcp -m tcp --dports 22 -o vnoi-vpn -j ACCEPT
 # HTTP, HTTPS to portal

--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -4,51 +4,42 @@
 :FORWARD ACCEPT [0:0]
 :OUTPUT DROP [0:0]
 
-# IMPORTANT (for people working on other services): non-sudo users must not be allowed to
-# host servers on low ports. Giving this permission will let them host a server on ports
-# 22 or 88 to receive information from outside using INPUT ACCEPT rules below. Even limiting
-# sources will not work due to possibility of IP spoofing.
-# TODO: Investigate possibility of communicating through port 10050 and 9090, spoofing as from {SUBNET}.
+-A INPUT -i lo -j ACCEPT                                                        # Loopback (localhost)
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT                         # Already existing connections
 
-# Loopback (localhost) incoming
--A INPUT -i lo -j ACCEPT
-# Already existing connections
--A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
-# Pings incoming
--A INPUT -p icmp -j ACCEPT
-# SSH for remote support.
-# TODO: Specify several sources for security while maintaining
-# recovery ability or disable password login completely.
--A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
-# Kerberos. TODO: Specify source for additional security in case of cred leak.
--A INPUT -p tcp -m tcp --dport 88 -j ACCEPT
-# Internal services
--A INPUT -p tcp -m tcp -s {SUBNET} --dport 10050 -j ACCEPT
--A INPUT -p tcp -m tcp -s {SUBNET} --dport 9090 -j ACCEPT
+-A INPUT -p icmp -i vnoi-vpn -j ACCEPT                                          # Pings
+-A INPUT -p tcp -m tcp --dport 22 -i vnoi-vpn -j ACCEPT                         # SSH
+-A INPUT -p tcp -m tcp --dport 88 -i vnoi-vpn -j ACCEPT                         # Kerberos
+-A INPUT -p tcp -m tcp -m multiport --dports 9090,10050 -i vnoi-vpn -j ACCEPT   # Internal services
 
-# Loopback (localhost) outgoing
--A OUTPUT -o lo -j ACCEPT
-# Already existing connections
--A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
-# Pings outgoing
--A OUTPUT -p icmp -j ACCEPT
+
+-A OUTPUT -o lo -j ACCEPT                                                       # Loopback (localhost)
+-A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT                        # Already existing connections
+
+-A OUTPUT -p icmp -i vnoi-vpn -j ACCEPT                                         # Pings
+-A OUTPUT -p tcp -m tcp --dports 22 -o vnoi-vpn -j ACCEPT                       # SSH
+-A OUTPUT -p tcp -m tcp -m multiport --dports 80,443 -o vnoi-vpn -j ACCEPT      # HTTP, HTTPS to portal
+-A OUTPUT -p tcp -m tcp -m multiport --dports 8000:9000 -o vnoi-vpn -j ACCEPT   # Internal services
+
 # Tinc outgoing. Restricted to central server at the address "vpn.vnoi". Specified in /etc/hosts.
 -A OUTPUT -p tcp -m tcp -d vpn.vnoi --dport 655 -j ACCEPT
 -A OUTPUT -p udp -m udp -d vpn.vnoi --dport 655 -j ACCEPT
+
 # DNS resolver. Restricted to servers managed by Google and Cloudflare (should be enough).
 -A OUTPUT -p tcp -m tcp --dport 53 -d 8.8.8.8,8.8.8.4,1.1.1.1,1.0.0.1 -j ACCEPT
 -A OUTPUT -p udp -m udp --dport 53 -d 8.8.8.8,8.8.8.4,1.1.1.1,1.0.0.1 -j ACCEPT
-# NTP, time sync. Restricted to ntp.ubuntu.com (Ubuntu's default), time.windows.com, time.nist.gov (Windows's choices)
+
+# NTP, time sync. Restricted to
+# Ubuntu's default: ntp.ubuntu.com
+# Windows's choices: time.windows.com, time.nist.gov
 -A OUTPUT -p udp -m udp --dport 123 -d ntp.ubuntu.com,time.windows.com,time.nist.gov -j ACCEPT
-# Internal services
--A OUTPUT -p tcp -m tcp -m multiport -d {SUBNET} --dports 22,80,443,8000:9000 -j ACCEPT
-# User portal. Restricted to webserver's domain. TODO: Consider placing in /etc/hosts.
--A OUTPUT -p tcp -m tcp -m multiport -d {WEBSERVER_PUBLIC_DOMAIN} --dports 80,443 -j ACCEPT
-# Authentication. TODO: Consider placing in /etc/hosts.
--A OUTPUT -p tcp -m tcp -m multiport -d {AUTH_ADDRESS} --dports 80,443,88,749,464,445,135,389 -j ACCEPT
--A OUTPUT -p udp -m udp -m multiport -d {AUTH_ADDRESS} --dports 88,4444,464,53,389 -j ACCEPT
+
+# HTTP, HTTPS to portal. Used if the VPN is down or portal is not connected to the VPN. Specified in /etc/hosts.
+-A OUTPUT -p tcp -m tcp -m multiport -d portal.vnoi --dports 80,443 -j ACCEPT
 # External resources. Will be enabled on a case-by-case basis.
--A OUTPUT -p tcp -m multiport -d fonts.gstatic.com --dports 80,443 -j ACCEPT
--A OUTPUT -p tcp -m multiport -d gravatar.com --dports 80,443 -j ACCEPT
--A OUTPUT -p tcp -m multiport -d cdnjs.cloudflare.com --dports 80,443 -j ACCEPT
+-A OUTPUT -p tcp -m multiport -d fonts.gstatic.com,gravatar.com,cdnjs.cloudflare.com --dports 80,443 -j ACCEPT
+
+# Authentication.
+-A OUTPUT -p tcp -m tcp -m multiport -d auth.vnoi --dports 80,443,88,749,464,445,135,389 -j ACCEPT
+-A OUTPUT -p udp -m udp -m multiport -d auth.vnoi --dports 88,4444,464,53,389 -j ACCEPT
 COMMIT

--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -4,22 +4,33 @@
 :FORWARD ACCEPT [0:0]
 :OUTPUT DROP [0:0]
 
--A INPUT -i lo -j ACCEPT                                                        # Loopback (localhost)
--A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT                         # Already existing connections
+# Loopback (localhost)
+-A INPUT -i lo -j ACCEPT
+# Already existing connections
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 
--A INPUT -p icmp -i vnoi-vpn -j ACCEPT                                          # Pings
--A INPUT -p tcp -m tcp --dport 22 -i vnoi-vpn -j ACCEPT                         # SSH
--A INPUT -p tcp -m tcp --dport 88 -i vnoi-vpn -j ACCEPT                         # Kerberos
--A INPUT -p tcp -m tcp -m multiport --dports 9090,10050 -i vnoi-vpn -j ACCEPT   # Internal services
+# Pings
+-A INPUT -p icmp -i vnoi-vpn -j ACCEPT
+# SSH
+-A INPUT -p tcp -m tcp --dport 22 -i vnoi-vpn -j ACCEPT
+# Kerberos
+-A INPUT -p tcp -m tcp --dport 88 -i vnoi-vpn -j ACCEPT
+# Internal services
+-A INPUT -p tcp -m tcp -m multiport --dports 9090,10050 -i vnoi-vpn -j ACCEPT
 
+# Loopback (localhost)
+-A OUTPUT -o lo -j ACCEPT
+# Already existing connections
+-A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 
--A OUTPUT -o lo -j ACCEPT                                                       # Loopback (localhost)
--A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT                        # Already existing connections
-
--A OUTPUT -p icmp -i vnoi-vpn -j ACCEPT                                         # Pings
--A OUTPUT -p tcp -m tcp --dports 22 -o vnoi-vpn -j ACCEPT                       # SSH
--A OUTPUT -p tcp -m tcp -m multiport --dports 80,443 -o vnoi-vpn -j ACCEPT      # HTTP, HTTPS to portal
--A OUTPUT -p tcp -m tcp -m multiport --dports 8000:9000 -o vnoi-vpn -j ACCEPT   # Internal services
+# Pings
+-A OUTPUT -p icmp -i vnoi-vpn -j ACCEPT
+# SSH
+-A OUTPUT -p tcp -m tcp --dports 22 -o vnoi-vpn -j ACCEPT
+# HTTP, HTTPS to portal
+-A OUTPUT -p tcp -m tcp -m multiport --dports 80,443 -o vnoi-vpn -j ACCEPT
+# Internal services
+-A OUTPUT -p tcp -m tcp -m multiport --dports 8000:9000 -o vnoi-vpn -j ACCEPT
 
 # Tinc outgoing. Restricted to central server at the address "vpn.vnoi". Specified in /etc/hosts.
 -A OUTPUT -p tcp -m tcp -d vpn.vnoi --dport 655 -j ACCEPT

--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -4,6 +4,12 @@
 :FORWARD ACCEPT [0:0]
 :OUTPUT DROP [0:0]
 
+# IMPORTANT (for people working on other services): non-sudo users must not be allowed to
+# host servers on low ports. Giving this permission will let them host a server on ports
+# 22 or 88 to receive information from outside using INPUT ACCEPT rules below. Even limiting
+# sources will not work due to possibility of IP spoofing.
+# TODO: Investigate possibility of communicating through port 10050 and 9090, spoofing as from {SUBNET}.
+
 # Loopback (localhost) incoming
 -A INPUT -i lo -j ACCEPT
 # Already existing connections
@@ -11,11 +17,10 @@
 # Pings incoming
 -A INPUT -p icmp -j ACCEPT
 # SSH for remote support.
-# TODO: Specify several sources for security while maintaining recovery ability
-# or disable password login completely.
+# TODO: Specify several sources for security while maintaining
+# recovery ability or disable password login completely.
 -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
-# Kerberos. TODO: Specify source for security. Beware of spoofing.
-# Incoming connections are still a method for communicating with outsiders, although one-way.
+# Kerberos. TODO: Specify source for additional security in case of cred leak.
 -A INPUT -p tcp -m tcp --dport 88 -j ACCEPT
 # Internal services
 -A INPUT -p tcp -m tcp -s {SUBNET} --dport 10050 -j ACCEPT

--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -26,7 +26,7 @@
 # Pings
 -A OUTPUT -p icmp -o vnoi-vpn -j ACCEPT
 # SSH
--A OUTPUT -p tcp -m tcp --dports 22 -o vnoi-vpn -j ACCEPT
+-A OUTPUT -p tcp -m tcp --dport 22 -o vnoi-vpn -j ACCEPT
 # HTTP, HTTPS to portal
 -A OUTPUT -p tcp -m tcp -m multiport --dports 80,443 -o vnoi-vpn -j ACCEPT
 # Internal services

--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -3,25 +3,46 @@
 :INPUT DROP [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT DROP [0:0]
+
+# Loopback (localhost) incoming
 -A INPUT -i lo -j ACCEPT
+# Already existing connections
 -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+# Pings incoming
 -A INPUT -p icmp -j ACCEPT
+# SSH for remote support.
+# TODO: Specify several sources for security while maintaining recovery ability
+# or disable password login completely.
 -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+# Kerberos. TODO: Specify source for security. Beware of spoofing.
+# Incoming connections are still a method for communicating with outsiders, although one-way.
 -A INPUT -p tcp -m tcp --dport 88 -j ACCEPT
+# Internal services
 -A INPUT -p tcp -m tcp -s {SUBNET} --dport 10050 -j ACCEPT
 -A INPUT -p tcp -m tcp -s {SUBNET} --dport 9090 -j ACCEPT
+
+# Loopback (localhost) outgoing
 -A OUTPUT -o lo -j ACCEPT
+# Already existing connections
 -A OUTPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+# Pings outgoing
 -A OUTPUT -p icmp -j ACCEPT
--A OUTPUT -p tcp -m tcp --dport 655 -j ACCEPT
--A OUTPUT -p udp -m udp --dport 655 -j ACCEPT
--A OUTPUT -p tcp -m tcp --dport 53 -j ACCEPT
--A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
--A OUTPUT -p udp -m udp --dport 123 -j ACCEPT
+# Tinc outgoing. Restricted to central server at the address "vpn.vnoi". Specified in /etc/hosts.
+-A OUTPUT -p tcp -m tcp -d vpn.vnoi --dport 655 -j ACCEPT
+-A OUTPUT -p udp -m udp -d vpn.vnoi --dport 655 -j ACCEPT
+# DNS resolver. Restricted to servers managed by Google and Cloudflare (should be enough).
+-A OUTPUT -p tcp -m tcp --dport 53 -d 8.8.8.8,8.8.8.4,1.1.1.1,1.0.0.1 -j ACCEPT
+-A OUTPUT -p udp -m udp --dport 53 -d 8.8.8.8,8.8.8.4,1.1.1.1,1.0.0.1 -j ACCEPT
+# NTP, time sync. Restricted to ntp.ubuntu.com (Ubuntu's default), time.windows.com, time.nist.gov (Windows's choices)
+-A OUTPUT -p udp -m udp --dport 123 -d ntp.ubuntu.com,time.windows.com,time.nist.gov -j ACCEPT
+# Internal services
 -A OUTPUT -p tcp -m tcp -m multiport -d {SUBNET} --dports 22,80,443,8000:9000 -j ACCEPT
+# User portal. Restricted to webserver's domain. TODO: Consider placing in /etc/hosts.
 -A OUTPUT -p tcp -m tcp -m multiport -d {WEBSERVER_PUBLIC_DOMAIN} --dports 80,443 -j ACCEPT
+# Authentication. TODO: Consider placing in /etc/hosts.
 -A OUTPUT -p tcp -m tcp -m multiport -d {AUTH_ADDRESS} --dports 80,443,88,749,464,445,135,389 -j ACCEPT
 -A OUTPUT -p udp -m udp -m multiport -d {AUTH_ADDRESS} --dports 88,4444,464,53,389 -j ACCEPT
+# External resources. Will be enabled on a case-by-case basis.
 -A OUTPUT -p tcp -m multiport -d fonts.gstatic.com --dports 80,443 -j ACCEPT
 -A OUTPUT -p tcp -m multiport -d gravatar.com --dports 80,443 -j ACCEPT
 -A OUTPUT -p tcp -m multiport -d cdnjs.cloudflare.com --dports 80,443 -j ACCEPT

--- a/src/sbin/firewall.sh
+++ b/src/sbin/firewall.sh
@@ -4,10 +4,7 @@ source /opt/vnoi/config.sh
 
 case "$1" in
 	start)
-		cat /opt/vnoi/misc/iptables.save | \
-			sed -e 's/{AUTH_ADDRESS}/'${AUTH_ADDRESS}'/g' | \
-			sed -e 's/{WEBSERVER_PUBLIC_DOMAIN}/'${WEBSERVER_PUBLIC_DOMAIN}'/g' | \
-			sed -e 's#{SUBNET}#'${SUBNET}'#g' | tee | /usr/sbin/iptables-restore
+		/usr/sbin/iptables-restore < /opt/vnoi/misc/iptables.save
 		/usr/sbin/ip6tables -P INPUT DROP
 		/usr/sbin/ip6tables -P OUTPUT DROP
 		logger -p local0.info "FIREWALL: started"


### PR DESCRIPTION
Added strict destination matching for all outgoing connections to harden security.

Remaining possible attack vectors:
- Communicating through ICMP (ICMP tunneling, https://github.com/DhavalKapil/icmptunnel). Hardening will be trade-off with ability to debug.
- Still allows input on ports 22,88,10050,9090 (with or without source restrictions, which doesn't mean anything since IP spoofing). Ports on subnet can be limited to the dev created by the vpn client (TODO: After finish VPN setup).

These are all the routes I could think of at the moment.

Firewall not tested. Requires vpn and kerberos on. Will be tested soon.