### PR TITLE
Change DROP to REJECT to enhance user experience and ease of debugging

### DIFF
--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -1,8 +1,8 @@
 # Default
 *filter
-:INPUT DROP [0:0]
+:INPUT REJECT [0:0]
 :FORWARD ACCEPT [0:0]
-:OUTPUT DROP [0:0]
+:OUTPUT REJECT [0:0]
 
 # Loopback (localhost)
 -A INPUT -i lo -j ACCEPT


### PR DESCRIPTION
DROP means that upon accessing a blocked site, users will have to wait for timeout and cannot differentiate between server failures and incorrect firewall setup. REJECT makes it easier to debug and hot-fix problems because we can pinpoint the exact issue if it's the firewall.

For INPUT, I'm also changing it to REJECT so that we can pinpoint connection issues if SSH access into contestant machines is blocked.