### PR TITLE
Allow pings to DNS servers

### DIFF
--- a/src/misc/iptables.save
+++ b/src/misc/iptables.save
@@ -23,6 +23,7 @@
 
 # Pings
 -A OUTPUT -p icmp -d {SUBNET} -j ACCEPT -o client
+-A OUTPUT -p icmp -d 8.8.8.8,8.8.4.4,1.1.1.1,1.0.0.1 -j ACCEPT
 # HTTP, HTTPS to portal(s)
 -A OUTPUT -p tcp -m tcp -m multiport --dports 80,443 -d {SUBNET} -j ACCEPT -o client
 # Internal services


### PR DESCRIPTION
DNS servers are the most resilient servers. Being able to ping these servers means you're connected to the internet, and the opposite is very likely to be true.

We should let the user ping DNS servers so that they can determine whether an Internet outage is their fault or VNOI central server's fault.