### PR TITLE
Increases robustness of webcam_stream_loop

### DIFF
--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -113,24 +113,21 @@ webcam_stream_loop() {
         echo "Waiting for cvlc or udevadm to exit"
         wait -fn -p TERMINATED_PID $UDEVADM_PID $CVLC_PID
         if [[ $TERMINATED_PID -eq $CVLC_PID ]]; then
-            echo "cvlc exited. Sending SIGTERM to udevadm"
-            RUNNING_PID=$UDEVADM_PID
+            echo "cvlc exited"
         else
-            echo "udevadm exited. Sending SIGTERM to cvlc"
-            RUNNING_PID=$CVLC_PID
+            echo "udevadm exited"
         fi
 
-        kill $RUNNING_PID
+        echo "Sending SIGTERM"
+        kill $UDEVADM_PID $CVLC_PID
 
-        echo "Waiting 3s for exit"
-        sleep 3 & SLEEP_PID=$!
+        echo "Waiting for 1s before sending SIGKILL"
+        sleep 1
 
-        # if sleep terminates first, RUNNING_PID will have to be killed
-        wait -fn -p TERMINATED_PID $RUNNING_PID $SLEEP_PID
-        if [ $TERMINATED_PID -eq $SLEEP_PID ]; then
-            echo "Timed out, sending SIGKILL"
-            kill -9 $RUNNING_PID
-        fi
+        echo "Sending SIGKILL"
+        kill -9 $UDEVADM_PID $CVLC_PID
+
+        sleep 0.1
     }
 
     webcam_pick_devices
@@ -154,7 +151,6 @@ webcam_stream_loop() {
         webcam_stream
 
         echo "Stream stopped. Restarting in 3s"
-
         # Sleep to prevent CPU hogging and let the processes be killed in any order
         sleep 3
     done

--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -55,22 +55,39 @@ vlc_restart_loop() {
 }
 
 webcam_stream_loop() {
-    VIDEO_DEVICE_NO=0
-    VIDEO_DEVICE_PATH="/dev/video$VIDEO_DEVICE_NO"
-    # We might need to use a different device
-    # Find out the correct device using aplay -L
-    AUDIO_DEVICE=alsa://plughw:0,0
-    while :
-    do
-        if ! [[ -e $VIDEO_DEVICE_PATH ]]; then
-            echo "Video device not found at $VIDEO_DEVICE_PATH. Available video devices"
-            echo "============"
-            ls -l "/dev/video"*
-            echo "============"
-            sleep 3
-            continue
-        fi
+    webcam_pick_devices() {
+        # Find device by unique identifiers
+        # https://docs.kernel.org/userspace-api/media/v4l/open.html#v4l2-device-node-naming
+        while :
+        do
+            echo "Looking for video devices"
 
+            local VIDEO_DEVICES
+            mapfile -t VIDEO_DEVICES < <(find /dev/v4l/by-id -regex ".*/usb-.*-video-index0")
+
+            local VIDEO_DEVICES_COUNT
+            VIDEO_DEVICES_COUNT=${#VIDEO_DEVICES[@]}
+
+            # Zero video devices
+            if [[ $VIDEO_DEVICES_COUNT -eq 0 ]]; then
+                echo "No video devices found"
+                sleep 3
+                continue
+            else
+                echo "Found $VIDEO_DEVICES_COUNT device(s): ${VIDEO_DEVICES[@]}"
+            fi
+
+            VIDEO_DEVICE_PATH=${VIDEO_DEVICES[0]}
+            echo "Using $VIDEO_DEVICE_PATH"
+
+            # We might need to use a different device
+            # Find out the correct device using aplay -L
+            AUDIO_DEVICE=alsa://plughw:0,0
+            return
+        done
+    }
+
+    webcam_stream() {
         # Monitor the video device using udevadm monitor
         # If device is unplugged, kill existing clvc instance to release /dev/video0
         echo "Starting udevadm to monitor video device connection"
@@ -82,7 +99,7 @@ webcam_stream_loop() {
         done &
         UDEVADM_PID=$!
 
-        echo "Starting cvlc instance for webcam streaming"
+        echo "Starting cvlc instance for streaming webcam $VIDEO_DEVICE_PATH"
         cvlc -vv -q v4l2://$VIDEO_DEVICE_PATH --v4l2-width=1280 --v4l2-height=720 \
         --input-slave $AUDIO_DEVICE \
         --sout \
@@ -110,8 +127,29 @@ webcam_stream_loop() {
             echo "Timeout waiting for cvlc and udevadm to exit, sending SIGKILL"
             kill -9 $UDEVADM_PID $CVLC_PID
         fi
+    }
 
-        echo "Restarting in 3 seconds"
+    webcam_pick_devices
+    while :
+    do
+        echo "Checking video device at $VIDEO_DEVICE_PATH"
+        if [[ -e $VIDEO_DEVICE_PATH ]]; then
+            echo "Video device found"
+        else
+            echo "Waiting 5s for device"
+            sleep 5
+
+            if [[ -e $VIDEO_DEVICE_PATH ]]; then
+                echo "Video device found"
+            else
+                echo "Video device not found. Picking new device"
+                webcam_pick_devices
+            fi
+        fi
+
+        webcam_stream
+
+        echo "Stream stopped. Restarting in 3s"
 
         # Sleep to prevent CPU hogging and let the processes be killed in any order
         sleep 3

--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -102,13 +102,13 @@ webcam_stream_loop() {
         fi
 
         echo "Sending SIGTERM to cvlc and udevadm"
-        kill $UDEVADM_PID $CVLC_PID || :
+        kill $UDEVADM_PID $CVLC_PID
 
         echo "Waiting for cvlc and udevadm to exit"
         # timeout returns 124 if the command times out
         timeout 3s wait -f $UDEVADM_PID $CVLC_PID; if [ $? -eq 124 ]; then
             echo "Timeout waiting for cvlc and udevadm to exit, sending SIGKILL"
-            kill -9 $UDEVADM_PID $CVLC_PID || :
+            kill -9 $UDEVADM_PID $CVLC_PID
         fi
 
         echo "Restarting in 3 seconds"

--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -91,12 +91,12 @@ webcam_stream_loop() {
         # Monitor the video device using udevadm monitor
         # If device is unplugged, kill existing clvc instance to release /dev/video0
         echo "Starting udevadm to monitor video device connection"
-        udevadm monitor --udev -s video4linux $VIDEO_DEVICE_PATH | while read -r line; do
+        while read -r line; do
             if [[ "$line" =~ "remove" ]] ; then
                 echo "Received video device removal: $line"
                 break
             fi
-        done &
+        done < <(udevadm monitor --udev -s video4linux) &
         UDEVADM_PID=$!
 
         echo "Starting cvlc instance for streaming webcam $VIDEO_DEVICE_PATH"

--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -86,7 +86,7 @@ webcam_stream_loop() {
             }" &
         CVLC_PID=$!
 
-        wait -n -p TERMINATED_PID $UDEVADM_PID $CVLC_PID
+        wait -fn -p TERMINATED_PID $UDEVADM_PID $CVLC_PID
         if [[ $TERMINATED_PID -eq $CVLC_PID ]]; then
             echo "cvlc exited"
         else

--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -23,6 +23,14 @@ if [ -f /run/icpc-startup.pid ]; then
     if kill -0 $STARTUP_PID && diff /proc/$STARTUP_PID/cmdline /proc/$$/cmdline; then
         echo "Killing existing startup"
         kill -- -$(cat /run/icpc-startup.pid)
+
+        echo "Waiting for 1s before sending SIGKILL"
+        sleep 1
+
+        echo "Sending SIGKILL"
+        kill -9 -- -$(cat /run/icpc-startup.pid)
+
+        sleep 0.1
     else
         echo "Removing stale startup pid file"
     fi

--- a/image-toolkit/sbin/startup.sh
+++ b/image-toolkit/sbin/startup.sh
@@ -62,6 +62,11 @@ webcam_stream_loop() {
     while :
     do
         if ! [[ -e $VIDEO_DEVICE_PATH ]]; then
+            echo "Video device not found at $VIDEO_DEVICE_PATH. Available video devices"
+            echo "============"
+            ls -l "/dev/video"*
+            echo "============"
+            sleep 3
             continue
         fi
 
@@ -98,6 +103,7 @@ webcam_stream_loop() {
         kill $UDEVADM_PID $CVLC_PID || :
 
         echo "VLC instance for webcam streaming exited, restarting in 3 seconds"
+
         # Sleep to prevent CPU hogging and let the processes be killed in any order
         sleep 3
     done


### PR DESCRIPTION
- Wait before retry if device not found
- Move udevadm before vlc to avoid missing remove events
- Check for cvlc and udevadm exit after sending SIGTERM. Terminate processes with SIGKILL if timeout
- Rewrite wait logic to terminate both cvlc and udevadm on failure of either processes.