### PR TITLE
ziap/monitoring

### DIFF
--- a/chroot_install.sh
+++ b/chroot_install.sh
@@ -68,7 +68,8 @@ apt-get install -y \
     wireguard \
     python3-psutil \
     nginx \
-    libnginx-mod-rtmp
+    libnginx-mod-rtmp \
+    prometheus-node-exporter
 
 # Install Chrome to avoid using Firefox snap. Firefox snap can't read stuffs not in ~/
 mkdir /tmp/chrome-download/

--- a/image-toolkit/misc/iptables.save
+++ b/image-toolkit/misc/iptables.save
@@ -21,6 +21,8 @@
 -A INPUT -p tcp -m tcp --dport 100 -s {ADMIN_SUBNET} -j ACCEPT -i client
 # HTTP services
 -A INPUT -p tcp -m tcp -m multiport --dports 80,443 -s {ADMIN_SUBNET} -j ACCEPT -i client
+# Node exporter output
+-A INPUT -p tcp -m tcp --dport 9100 -s {ADMIN_SUBNET} -j ACCEPT -i client
 
 # Coach views
 # VLC output

--- a/image-toolkit/setup.sh
+++ b/image-toolkit/setup.sh
@@ -202,6 +202,9 @@ NAutoVTs=0
 ReserveVT=0
 EOM
 
+# Enable prometheus node exporter
+systemctl enable prometheus-node-exporter
+
 # Disable updates
 
 cat - <<EOM > /etc/apt/apt.conf.d/20auto-upgrades


### PR DESCRIPTION
This PR adds the Prometheus machine metrics exporter endpoint for monitoring:

- Add the `prometheus-node-exporter` apt package and systemd service.
- Configure the firewall to expose the port `:9100` (default node exporter port) to the admin server.